### PR TITLE
Implement skill evolution and passive item effects

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -166,7 +166,7 @@ def start_game():
             p.add_item(item_received)
 
         # --- 回合結束階段 ---
-        end_of_turn_effects(p)
+        end_of_turn_effects(p, w)
 
         # 檢查遊戲是否結束
         if is_game_over(p, w):
@@ -243,7 +243,7 @@ def is_game_over(p, w):
     # 未來可以加入更多失敗條件，例如腐化過高、世界毀滅等
     return False
 
-def end_of_turn_effects(p):
+def end_of_turn_effects(p, w):
     """
     處理回合結束時的增益/減益效果。
     """
@@ -260,3 +260,21 @@ def end_of_turn_effects(p):
         if not p.active_effects[attr]:
             del p.active_effects[attr]
         print(f"【系統】來自 {item_name} 的效果已結束。")
+
+    # 處理裝備的被動效果
+    for slot, item_name in p.equipment.items():
+        if not item_name:
+            continue
+        item = w.items.get(item_name)
+        if not item:
+            continue
+        passive = item.get("passive")
+        if not passive:
+            continue
+        if "heal" in passive:
+            p.heal(passive["heal"], w)
+        if "corruption" in passive:
+            p.corruption += passive["corruption"]
+            print(
+                f"【系統】{item_name} 的黑暗氣息讓你的腐化值增加 {passive['corruption']}。"
+            )

--- a/src/player.py
+++ b/src/player.py
@@ -370,7 +370,7 @@ class Player:
             if choice == '1':
                 self.increase_attributes(world)
             elif choice == '2':
-                print("此功能尚未開放，敬請期待！")
+                self.evolve_skills(world)
             elif choice == '3':
                 break
             else:
@@ -419,3 +419,49 @@ class Player:
                 print(f"{attr_choice} 已提升至 {self.attributes[attr_choice]}！")
             else:
                 print("已取消提升。")
+
+    def evolve_skill(self, skill_name, world):
+        """嘗試將指定技能進化，成功時回傳 True。"""
+        if skill_name not in self.skills:
+            print("你沒有這個技能。")
+            return False
+
+        tree = world.skill_tree.get(skill_name)
+        if not tree:
+            print("此技能無法進化。")
+            return False
+
+        cost = tree["cost"]
+        next_skill = tree["next"]
+
+        if self.growth_points < cost:
+            print("你的 GP 不足。")
+            return False
+
+        self.skills[self.skills.index(skill_name)] = next_skill
+        self.growth_points -= cost
+        print(f"{skill_name} 已進化為 {next_skill}！剩餘 {self.growth_points} GP。")
+        return True
+
+    def evolve_skills(self, world):
+        """互動式技能進化流程。"""
+        while True:
+            print("\n--- 技能進化 ---")
+            available = {}
+            for idx, skill in enumerate(self.skills, start=1):
+                if skill in world.skill_tree:
+                    info = world.skill_tree[skill]
+                    print(f"{idx}. {skill} -> {info['next']} (花費 {info['cost']} GP)")
+                    available[str(idx)] = skill
+            if not available:
+                print("目前沒有可進化的技能。")
+                return
+
+            choice = input("選擇要進化的技能編號，或輸入 '返回': ")
+            if choice == '返回':
+                return
+            if choice not in available:
+                print("無效的選擇。")
+                continue
+
+            self.evolve_skill(available[choice], world)

--- a/src/world.py
+++ b/src/world.py
@@ -13,6 +13,13 @@ class World:
             "半獸人（海洋）": {"description": "適應海洋生活，能在水中自由呼吸。", "skills": ["水下呼吸"]},
             "龍裔": {"description": "擁有龍的血脈，天生就具有強大的力量。", "skills": ["龍之吐息"]},
         }
+        # 技能進化樹，用於處理技能進化系統
+        self.skill_tree = {
+            "駭客術": {"next": "資料探勘", "cost": 3},
+            "資料探勘": {"next": "神經入侵", "cost": 5},
+            "火球術": {"next": "烈焰爆破", "cost": 3},
+            "烈焰爆破": {"next": "流星焚界", "cost": 5},
+        }
         self.items = {
             # 消耗品
             "治療藥水": {
@@ -91,7 +98,8 @@ class World:
                 "slot": "accessory",
                 "description": "一枚古老的銀製護符，在月光下會發出微光。",
                 "faith_effect": {"月神": 5},
-                "ability": "月光祝福"
+                "ability": "月光祝福",
+                "passive": {"heal": 5}
             },
             "太陽神徽記": {
                 "type": "神器",
@@ -129,7 +137,8 @@ class World:
                 "description": "一把由黑曜石打造的匕首，似乎會在你耳邊低語。",
                 "corruption_effect": 5,
                 "bonus": {"STR": 2},
-                "curse": "持有者會時常聽到幻聽，進行專注相關的檢定時可能會有減益。"
+                "curse": "持有者會時常聽到幻聽，進行專注相關的檢定時可能會有減益。",
+                "passive": {"corruption": 1}
             },
             "腐化之顱": {
                 "type": "魔王遺物",

--- a/tests/test_passive_effects.py
+++ b/tests/test_passive_effects.py
@@ -1,0 +1,29 @@
+import os
+import sys
+base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, base_dir)
+sys.path.insert(0, os.path.join(base_dir, 'src'))
+
+import types
+
+fake = types.ModuleType("narrator")
+fake.Narrator = object
+sys.modules["narrator"] = fake
+
+from src import player, world, game
+
+
+def test_passive_heal_and_corruption():
+    w = world.World()
+    p = player.Player()
+    # add items to inventory and equip them
+    p.inventory = ["月神護符", "低語匕首"]
+    p.equip_item("月神護符", w)
+    p.equip_item("低語匕首", w)
+    # reduce hp to test heal
+    p.hp = p.get_max_hp(w) - 10
+    game.end_of_turn_effects(p, w)
+    assert p.hp == p.get_max_hp(w) - 5
+    assert p.corruption == 1 + 5  # initial equip added 5, passive adds 1
+
+

--- a/tests/test_skill_evolution.py
+++ b/tests/test_skill_evolution.py
@@ -1,0 +1,30 @@
+import os
+import sys
+base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, base_dir)
+sys.path.insert(0, os.path.join(base_dir, 'src'))
+
+import pytest
+from src import player, world
+
+
+def test_evolve_skill_success():
+    w = world.World()
+    p = player.Player()
+    p.skills = ["駭客術"]
+    p.growth_points = 5
+    assert p.evolve_skill("駭客術", w)
+    assert p.skills == ["資料探勘"]
+    assert p.growth_points == 2
+
+
+def test_evolve_skill_insufficient_gp():
+    w = world.World()
+    p = player.Player()
+    p.skills = ["火球術"]
+    p.growth_points = 2
+    assert not p.evolve_skill("火球術", w)
+    assert p.skills == ["火球術"]
+
+
+


### PR DESCRIPTION
## Summary
- add skill tree and evolution methods
- apply passive item effects at end of turn
- create unit tests for skill evolution and passive effects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf9e1cc708328bdbc67a6a85a92e3